### PR TITLE
V0.0.16 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Release 0.0.16 (small update)
+- Updated @typhonjs-fvtt/svelte-standard to ['0.0.19'](https://github.com/typhonjs-fvtt-lib/svelte-standard/blob/main/CHANGELOG.md#release-0019).
+
 ## Release 0.0.15 (major update)
 - Updated @typhonjs-fvtt/runtime to ['0.0.22'](https://github.com/typhonjs-fvtt-lib/typhonjs/blob/main/CHANGELOG.md#release-0022).
 - Updated @typhonjs-fvtt/svelte-standard to ['0.0.18'](https://github.com/typhonjs-fvtt-lib/svelte-standard/blob/main/CHANGELOG.md#release-0018).

--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
       "url": "https://www.typhonjs.io"
     }
   ],
-  "version": "0.0.15",
+  "version": "0.0.16",
   "compatibility": {
     "minimum": "10",
     "verified": "10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "essential-svelte-esm",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "essential-svelte-esm",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
         "@typhonjs-fvtt/runtime": "^0.0.22",
-        "@typhonjs-fvtt/svelte-standard": "^0.0.18",
+        "@typhonjs-fvtt/svelte-standard": "^0.0.19",
         "svelte": "^3.55.0"
       },
       "devDependencies": {
@@ -19,6 +19,10 @@
         "eslint": "^8",
         "svelte-preprocess": "^5",
         "vite": "^4"
+      },
+      "peerDependencies": {
+        "@rollup/plugin-node-resolve": "^15",
+        "@sveltejs/vite-plugin-svelte": "^2"
       }
     },
     "node_modules/@csstools/postcss-cascade-layers": {
@@ -863,9 +867,9 @@
       }
     },
     "node_modules/@typhonjs-fvtt/svelte-standard": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.18.tgz",
-      "integrity": "sha512-PvExGZ7CC8fYWhRdVEYCPNvaAa3uN+jdPbEgbgzwv1EPmFBwZI7BMEfDX0P5ub2Dk9D7BEMjoVi8JarwMjfnFQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.19.tgz",
+      "integrity": "sha512-LGMY8vR/ahaPbYgmkal/3wPXKPMbLgVkcnXLjXh1yI42NQj2sxOQ7OwaVUfgy7O2pJHMTOjkiVIs7DCTox9Geg==",
       "engines": {
         "node": ">=14.18"
       }
@@ -4467,9 +4471,9 @@
       }
     },
     "@typhonjs-fvtt/svelte-standard": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.18.tgz",
-      "integrity": "sha512-PvExGZ7CC8fYWhRdVEYCPNvaAa3uN+jdPbEgbgzwv1EPmFBwZI7BMEfDX0P5ub2Dk9D7BEMjoVi8JarwMjfnFQ=="
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.19.tgz",
+      "integrity": "sha512-LGMY8vR/ahaPbYgmkal/3wPXKPMbLgVkcnXLjXh1yI42NQj2sxOQ7OwaVUfgy7O2pJHMTOjkiVIs7DCTox9Geg=="
     },
     "acorn": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-svelte-esm",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Provides essential TRL demos for reactivity and beyond.",
   "license": "MIT",
   "private": true,
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "@typhonjs-fvtt/runtime": "^0.0.22",
-    "@typhonjs-fvtt/svelte-standard": "^0.0.18",
+    "@typhonjs-fvtt/svelte-standard": "^0.0.19",
     "svelte": "^3.55.0"
   },
   "devDependencies": {
@@ -20,6 +20,10 @@
     "eslint": "^8",
     "svelte-preprocess": "^5",
     "vite": "^4"
+  },
+  "peerDependencies" : {
+    "@sveltejs/vite-plugin-svelte": "^2",
+    "@rollup/plugin-node-resolve": "^15"
   },
   "browserslist": [">5%", "not IE 11"],
   "scripts": {


### PR DESCRIPTION
## Release 0.0.16 (small update)
- Updated @typhonjs-fvtt/svelte-standard to ['0.0.19'](https://github.com/typhonjs-fvtt-lib/svelte-standard/blob/main/CHANGELOG.md#release-0019).
